### PR TITLE
Alterado para aceitar valor 0

### DIFF
--- a/src/Keeper.php
+++ b/src/Keeper.php
@@ -43,7 +43,7 @@ class Keeper {
         $contextToUse = $this->getContext($context);
 
         foreach($inputs as $key => $value) {
-            if ((boolean)$value) {
+            if (!empty($value) || is_numeric($value)) {
                 $this->session->put("keeper.$contextToUse.$key", $value);
             } else {
                 $this->forget($key, $context);


### PR DESCRIPTION
Quando o valor a ser filtrado era 0 o boolean estava entendendo como false e esquecendo(forget) o filtro, dessa maneira ele esquece quando for vazio e diferente de 0
